### PR TITLE
create directory on remote server - story #12

### DIFF
--- a/sftpshellfuncs.py
+++ b/sftpshellfuncs.py
@@ -53,6 +53,34 @@ def list_content(sftp, args):
     except Exception as e:
         print(f"Error listing directory or files: {str(e)}")
 
+#below function creates directory on remote server using mkdir command
+def make_directory(sftp, args):
+    if sftp == None:
+        print("\nWarning: SFTP client is not connected")
+        return
+    
+    #show error message if no argument is passed
+    if len(args) < 2:
+        print("Error: Invalid argument. Please enter the directory name to be created. For example: mkdir new_directory")
+        return
+    
+    #show error message if more than one argument is passed
+    if len(args) > 2:
+        print("Error: Invalid argument. Please enter only one argument. For example: mkdir new_directory")
+        return
+    
+    directory_name = args[1] #get the directory name from the argument
+    try:
+        #check if the directory already exists
+        if sftp.isdir(directory_name):
+            print(f"Error: There is an existing directory with the name '{directory_name}' Please use another name for creating a new directory")
+            return
+        else:
+            sftp.mkdir(directory_name)
+            print(f"Directory {directory_name} created successfully")
+    except Exception as e:
+        print(f"Error creating directory: {str(e)}")
+
 # Saiteja G 7/19/2023
 # Function to close SFTP connection
 def logout(sftp):
@@ -137,6 +165,7 @@ commands["command_name"] = command_function_name
 commands["help"] = help
 commands["ls"] = list_content
 commands["get_file"] = get_file_remote_server
+commands["mkdir"] = make_directory
 
 
 commands["closeconn"] = tologOut


### PR DESCRIPTION
user can create a directory in pwd path using "mkdir directory_name".
Handles error (1) if user does not pass directory name argument, (2) if passed two arguments-throws another error, (3) if user passes a directory name that already exists in the pwd path-throws another error.